### PR TITLE
Adding ability for user to add custom classes to the card wrapper

### DIFF
--- a/app/helpers/deckster/deck_helper.rb
+++ b/app/helpers/deckster/deck_helper.rb
@@ -15,6 +15,7 @@ module Deckster
       #    :async => Summary and Detail are both load asynchronously
       # :summary_url => convention override for the summary card
       # :detail_url => convention override for the detail card
+      # :card_classes => custom css class(es) to add to the card wrapper
 
       card_config[:title] ||= card_config[:card].to_s.titleize
       card_config[:load] ||= :fully
@@ -29,7 +30,8 @@ module Deckster
           sym: card_config[:card], title: card_config[:title], tooltip: card_config[:tooltip],
           summary_html: summary_html,
           detail_html: detail_html,
-          row: card_config[:row], col: card_config[:col], sizex: card_config[:sizex], sizey: card_config[:sizey]
+          row: card_config[:row], col: card_config[:col], sizex: card_config[:sizex],
+          sizey: card_config[:sizey], card_classes: card_config[:card_classes]
       }
     end
 

--- a/app/views/deckster/deck/_card.html.erb
+++ b/app/views/deckster/deck/_card.html.erb
@@ -1,4 +1,4 @@
-<div id="<%= sym %>" class="deckster-card well well-lg" data-col="<%= col %>" data-row="<%= row %>" data-sizex="<%= sizex %>" data-sizey="<%= sizey %>" data-title="<%= title %>" style="position: absolute;">
+<div id="<%= sym %>" class="deckster-card well well-lg <%= card_classes %>" data-col="<%= col %>" data-row="<%= row %>" data-sizex="<%= sizex %>" data-sizey="<%= sizey %>" data-title="<%= title %>" style="position: absolute;">
   <nav class="navbar navbar-default" role="navigation">
     <div class="container-fluid deckster-card-title">
       <div class="navbar-header">

--- a/test/dummy/app/helpers/client_tools_deck_helper.rb
+++ b/test/dummy/app/helpers/client_tools_deck_helper.rb
@@ -1,7 +1,7 @@
 module ClientToolsDeckHelper
   def render_client_tools_deck
     render_deckster_deck :sample_deck_a, [
-        {card: :jquery, load: :async, title: 'jQuery', row: 1, col: 1, sizex: 1, sizey: 1},
+        {card: :jquery, load: :async, title: 'jQuery', card_classes: 'jquery-card', row: 1, col: 1, sizex: 1, sizey: 1},
         {card: :bootstrap, load: :async, row: 1, col: 2, sizex: 1, sizey: 1},
         {card: :font_awesome, load: :async, title: 'Font Awesome', load: :async, row: 1, col: 3, sizex: 1, sizey: 1},
         {card: :gridster, load: :async, load: :async, row: 1, col: 4, sizex: 1, sizey: 1},


### PR DESCRIPTION
users can now specify a card_classes configuration parameter in the card config that will attach a css class(es) to the card to allow for individual css targeting. 
